### PR TITLE
Fix team creation

### DIFF
--- a/src/Audit.cs
+++ b/src/Audit.cs
@@ -109,7 +109,7 @@ namespace gitman
             if (!string.IsNullOrEmpty(outputPath))
             {
                 var path = Path.Combine(outputPath, $"audit_{DateTime.Now.ToString("yyy-MM-dd-hhmm")}.json");
-                l($"Saving audit repot to {path}", 1);
+                l($"Saving audit report to {path}", 1);
                 using var writer = new StreamWriter(path);
                 JSON.Serialize(Data, writer, Jil.Options.PrettyPrintCamelCase);
             }

--- a/src/GitWrapper/GitWrapper.cs
+++ b/src/GitWrapper/GitWrapper.cs
@@ -24,10 +24,9 @@ namespace gitman
         public async Task<GitTeam> GetTeamAsync(string name) {
             await CacheTeamsAsync();
             var team = teamsByIds.SingleOrDefault(t => t.Key.Equals(name));
-            if (team.Equals(default(KeyValuePair<int, Team>))) {
-                return null;
+            if (team.Equals(default(KeyValuePair<string, Team>))) {
+                return new GitTeam();
             }
-
             return new GitTeam(team.Value);
         }
 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -80,7 +80,7 @@ namespace gitman
 
             if (Config.HasRepoStructureFile) {
                 Console.WriteLine("Checking repository access");
-                await new RepositoryAccess(GetRepositoryDescription()) { Client = client, Wrapper = wrapper }.Do();
+                await new RepositoryAccess(GetRepositoryDescription(), audit.Data) { Client = client, Wrapper = wrapper }.Do();
             }
 
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -60,11 +60,6 @@ namespace gitman
             Console.WriteLine("\n\nChecking repo collaborators");
             var wrapper = new GitWrapper(client);
 
-            if (Config.HasRepoStructureFile) {
-                Console.WriteLine("Checking repository access");
-                await new RepositoryAccess(GetRepositoryDescription()) { Client = client, Wrapper = wrapper }.Do();
-            }
-
             Console.WriteLine("\n\nChecking branch protections");
             await new Protection() { Client = client }.Do();
 
@@ -75,13 +70,19 @@ namespace gitman
             if (Config.HasTeamsStructureFile)
             {
                 var teams = GetTeams();
-                
+
                 Console.WriteLine("\n\nChecking teams");
                 await new Teams(audit.Data, teams) { Client = client }.Do();
 
                 Console.WriteLine("\n\nChecking teams memberships");
                 await new TeamMemberships(audit.Data, teams) { Client = client }.Do();
             }
+
+            if (Config.HasRepoStructureFile) {
+                Console.WriteLine("Checking repository access");
+                await new RepositoryAccess(GetRepositoryDescription()) { Client = client, Wrapper = wrapper }.Do();
+            }
+
         }
 
         private static Dictionary<string, List<string>> GetTeams() 

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -67,20 +67,25 @@ namespace gitman
             var audit = new Audit(outputPath: Config.ReportingPath) { Client = client };
             await audit.Do();
 
+            var proposed_teams = default(IEnumerable<string>);
+
             if (Config.HasTeamsStructureFile)
             {
                 var teams = GetTeams();
+
+                proposed_teams = teams.Keys;
 
                 Console.WriteLine("\n\nChecking teams");
                 await new Teams(audit.Data, teams) { Client = client }.Do();
 
                 Console.WriteLine("\n\nChecking teams memberships");
                 await new TeamMemberships(audit.Data, teams) { Client = client }.Do();
+
             }
 
             if (Config.HasRepoStructureFile) {
                 Console.WriteLine("Checking repository access");
-                await new RepositoryAccess(GetRepositoryDescription(), audit.Data) { Client = client, Wrapper = wrapper }.Do();
+                await new RepositoryAccess(GetRepositoryDescription(), proposed_teams) { Client = client, Wrapper = wrapper }.Do();
             }
 
         }

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -17,12 +17,12 @@ namespace gitman
             var opts = new OptionSet() {
                 {"u|user=", "(REQUIRED) A github user with admin access.", u => Config.Github.User = u}
                 , {"t|token=", "(REQUIRED) A github token that has admin access to the org.", t => Config.Github.Token = t  }
-                , {"o|org=", "The organisation we need to run the actions against (defaults to `sectigo-eng`)", o => Config.Github.Org = o}
+                , {"o|org=", "The organization we need to run the actions against (defaults to `sectigo-eng`)", o => Config.Github.Org = o}
                 , {"teams=", "A file with the desired team structure in JSON format. If this is set, this will enforce that team structure (including removing members from teams). We expect a Dictionary where the key is the team name, and the value a list of string with the user login names.", ts => Config.TeamStructureFile = ts }
                 , {"repos=", "A file with the desired repository teams access in JSON format.", rs => Config.RepoStructureFile = rs }
                 , {"report=", "The path were we output the audit report. This defaults to ./", o => Config.ReportingPath = o }
-                , {"d|dryrun=", "Should this run authorative updates (`no`-dryrun), or only display changes (`yes` do a dryrun please). Must be either 'yes' or 'no'. Defaults to 'yes'.", (string dry) => Config.DryRunMode = dry.ToLower() }
-                , {"no-dryrun", "Run authoratives updates. This can be destructive. This is the greedy option over --dryrun=yes|no.", d => Config.DryRunMode = "no" }
+                , {"d|dryrun=", "Should this run authoritative updates (`no`-dryrun), or only display changes (`yes` do a dryrun please). Must be either 'yes' or 'no'. Defaults to 'yes'.", (string dry) => Config.DryRunMode = dry.ToLower() }
+                , {"no-dryrun", "Run authoritative updates. This can be destructive. This is the greedy option over --dryrun=yes|no.", d => Config.DryRunMode = "no" }
                 , {"validate=", "Should this run include validation checks (does X exist or not). Excluding these saves significant api hits for rate limiting. Must be either `yes` or `no`. Defaults to `yes`)", (string val) => Config.ValidationMode = val.ToLower() }
                 , {"h|help", p => Config.Help = true}
             };

--- a/src/RepositoryAccess.cs
+++ b/src/RepositoryAccess.cs
@@ -11,9 +11,12 @@ namespace gitman {
 
         private RepositoryDescription desciption;
 
-        public RepositoryAccess(RepositoryDescription description) 
+        private Audit.AuditDto auditData;
+
+        public RepositoryAccess(RepositoryDescription description, Audit.AuditDto auditData) 
         {
             this.desciption = description;
+            this.auditData = auditData;
         }
 
         public override async Task Do()
@@ -44,8 +47,9 @@ namespace gitman {
         {    
             // Validate team names
             var existingTeams = await Wrapper.GetTeamsAsync();
+            var teamsFromConfig = auditData.Teams.Values;
             var teamNames = desciption.TeamDescriptions.Select(t => t.TeamName);
-            var teamDoesNotExist = teamNames.Where(t => !existingTeams.Any(et => et.Equals(t)));
+            var teamDoesNotExist = teamNames.Where(t => !teamsFromConfig.Any(tfc => tfc.Equals(t)));
 
             // validates repo list references to actual repo lists
             var repoListRefs = desciption.TeamDescriptions.SelectMany(t => new [] { t.Not, t.Only } ).Where(r => !string.IsNullOrEmpty(r)).Distinct();

--- a/src/RepositoryAccess.cs
+++ b/src/RepositoryAccess.cs
@@ -9,13 +9,13 @@ namespace gitman {
     {
         public IGitWrapper Wrapper { get; set; }
 
-        private RepositoryDescription desciption;
+        private RepositoryDescription description;
 
         private Audit.AuditDto auditData;
 
         public RepositoryAccess(RepositoryDescription description, Audit.AuditDto auditData) 
         {
-            this.desciption = description;
+            this.description = description;
             this.auditData = auditData;
         }
 
@@ -31,12 +31,12 @@ namespace gitman {
             }
 
             // Resolve and apply the collaborators
-            foreach (var team in desciption.TeamDescriptions)
+            foreach (var team in description.TeamDescriptions)
             {
                 // Resolve the repo lists
                 IEnumerable<string> not = null, only = null;
-                ResolveList(desciption.RepoLists, team.Not, ref not);
-                ResolveList(desciption.RepoLists, team.Only, ref only);
+                ResolveList(description.RepoLists, team.Not, ref not);
+                ResolveList(description.RepoLists, team.Only, ref only);
 
                 // Check the collaborators
                 await new Collaborators(Wrapper, team.TeamName, team.Permission, only, not) { Client = this.Client }.Do();
@@ -48,12 +48,12 @@ namespace gitman {
             // Validate team names
             var existingTeams = await Wrapper.GetTeamsAsync();
             var teamsFromConfig = auditData.Teams.Values;
-            var teamNames = desciption.TeamDescriptions.Select(t => t.TeamName);
+            var teamNames = description.TeamDescriptions.Select(t => t.TeamName);
             var teamDoesNotExist = teamNames.Where(t => !teamsFromConfig.Any(tfc => tfc.Equals(t)));
 
             // validates repo list references to actual repo lists
-            var repoListRefs = desciption.TeamDescriptions.SelectMany(t => new [] { t.Not, t.Only } ).Where(r => !string.IsNullOrEmpty(r)).Distinct();
-            var repoListDoesNotExist = repoListRefs.Where(r => !desciption.RepoLists.ContainsKey(r));
+            var repoListRefs = description.TeamDescriptions.SelectMany(t => new [] { t.Not, t.Only } ).Where(r => !string.IsNullOrEmpty(r)).Distinct();
+            var repoListDoesNotExist = repoListRefs.Where(r => !description.RepoLists.ContainsKey(r));
             
             var message = "";
             if (teamDoesNotExist.Any())
@@ -64,7 +64,7 @@ namespace gitman {
             }
             if (repoListDoesNotExist.Any())
             {
-                message += "Repo list referece do not match pre-defined list\n";
+                message += "Repo list reference do not match pre-defined list\n";
                 message += string.Join("\n", repoListDoesNotExist.Select(r => $"\t - {r}").ToArray());
                 message += "\n";
             }


### PR DESCRIPTION
The gitman audit prevents the creation of new teams. The audit fails because the configuration updates reference a team that does not exist yet in the GitHub organization.

This PR changes the current validation logic. If the user provides a teams.json file, consider the teams defined in that configuration file to validate that all the teams referenced in the configuration. Otherwise, fallback on the existing teams currently present in the GitHub organization.

It makes sense to consider the teams in the desired configuration as reference because the desired state is represented by the configuration file if one has been provided by the user.